### PR TITLE
ENH: increase labels by one

### DIFF
--- a/fragmenter/Fragment.py
+++ b/fragmenter/Fragment.py
@@ -115,4 +115,7 @@ class Fragment(object):
 
                     label[parcel_idx] = clusters
 
+        # Increase labels by one to prevent transparent mesh
+        label += 1
+
         self.label_ = label

--- a/fragmenter/NullModels.py
+++ b/fragmenter/NullModels.py
@@ -42,6 +42,9 @@ class NullModel(object):
         kdnn = K.query(self.sphere[self.mask, :], k=1)
         kd_label = self.label[kdnn[1]]
 
+        # Increase labels by one to prevent transparent mesh
+        kd_label += 1
+
         return kd_label
 
     def _rotate(self, maxd_x=10, maxd_y=10, maxd_z=10):


### PR DESCRIPTION
The reason why the mesh outside the ROI was transparent was because the label of these vertices was 0. By increasing the labels of each vertex by one, every vertex will be colored.