### PR TITLE
Expand Fragment.write capabilities

### DIFF
--- a/fragmenter/Fragment.py
+++ b/fragmenter/Fragment.py
@@ -131,22 +131,25 @@ class Fragment(object):
 
         self.label_ = np.int32(label)
 
-    def write(self, output_name, use_pretty_colors=True, to_file=False):
+    def write(self, output_name, to_file=False):
         """
         Write the fragmented label file to FreeSurfer annotation file.
 
         Parameters:
         - - - - -
         output_name: string
-            name of save file to
+            name of save file. Must contain desired file extension (e.g. '.annot', '.csv') 
+        to_file: boolean
+            indicate whether to create a txt or csv file instead 
         """
 
         # If labels are to be exported to csv
         if to_file:
-            np.savetxt((output_name + ".csv"), self.label_, fmt='%5.0f')
+            np.savetxt(output_name, self.label_, fmt='%5.0f')
         # Otherwise write an annotation file with freesurfer    
         else:
-            [keys, ctab, names, remapped] = colormaps.get_ctab_and_names(
-                self.vertices, self.label_, use_pretty_colors=use_pretty_colors)
-
+            [keys,ctab,names,remapped] = colormaps.get_ctab_and_names(
+                self.vertices, self.label_, use_pretty_colors=self.use_pretty_colors)
             freesurfer.io.write_annot(output_name, remapped, ctab, names)
+
+

--- a/fragmenter/Fragment.py
+++ b/fragmenter/Fragment.py
@@ -139,7 +139,7 @@ class Fragment(object):
         - - - - -
         output_name: string
             name of save file. Must contain desired file extension (e.g. '.annot', '.csv') 
-        to_file: boolean
+        to_file: bool
             indicate whether to create a txt or csv file instead 
         """
 

--- a/fragmenter/Fragment.py
+++ b/fragmenter/Fragment.py
@@ -131,7 +131,7 @@ class Fragment(object):
 
         self.label_ = np.int32(label)
 
-    def write(self, output_name, use_pretty_colors=True):
+    def write(self, output_name, use_pretty_colors=True, to_file=False):
         """
         Write the fragmented label file to FreeSurfer annotation file.
 
@@ -141,7 +141,12 @@ class Fragment(object):
             name of save file to
         """
 
-        [keys, ctab, names, remapped] = colormaps.get_ctab_and_names(
-            self.vertices, self.label_, use_pretty_colors=use_pretty_colors)
+        # If labels are to be exported to csv
+        if to_file:
+            np.savetxt((output_name + ".csv"), self.label_, fmt='%5.0f')
+        # Otherwise write an annotation file with freesurfer    
+        else:
+            [keys, ctab, names, remapped] = colormaps.get_ctab_and_names(
+                self.vertices, self.label_, use_pretty_colors=use_pretty_colors)
 
-        freesurfer.io.write_annot(output_name, remapped, ctab, names)
+            freesurfer.io.write_annot(output_name, remapped, ctab, names)

--- a/fragmenter/colormaps.py
+++ b/fragmenter/colormaps.py
@@ -55,6 +55,8 @@ def get_ctab_and_names(coords, labels, use_pretty_colors=True):
         [np.bytes_('parc_%i' % (i)) for i in unique_ids]
 
     # Reorder table and names according distance to sphere "bottom"
+    # Set keys globally so return doesn't break if pretty_colors=false
+    keys="No remapping done"
     if use_pretty_colors:
 
         # Compute mean height (on z-axis) per label to resort color table

--- a/fragmenter/colormaps.py
+++ b/fragmenter/colormaps.py
@@ -56,7 +56,7 @@ def get_ctab_and_names(coords, labels, use_pretty_colors=True):
 
     # Reorder table and names according distance to sphere "bottom"
     # Set keys globally so return doesn't break if pretty_colors=false
-    keys="No remapping done"
+    keys="No color remapping done"
     if use_pretty_colors:
 
         # Compute mean height (on z-axis) per label to resort color table


### PR DESCRIPTION
This is in response to issue #19 . Instructions on how to make these HCP-compatible are in the Demo notebook.

**Modifications**:

1) The writer now takes in the initial definition of `fragment_object.use_pretty_colors`. I believe this was the point of selecting whether to use pretty colors or not when creating the fragment object originally.

2) Added bool option `to_file` to export to csv or txt instead of .annot (in every case, `output_name` must contain the desired file extension). 

3) The `colormaps` function was breaking if `use_pretty_colors=False` because `keys` was not defined in that case. Fixed it by declaring `keys` outside of the if statement.

**Things I just realized I forgot to do**: 

1) Update the Demo with the new syntax, but that should be straightforward.

2) Add a test to ensure that file extension is added to `output_name`

All the resulting generated files were visually checked using freeview.