### PR TITLE
Demo export and test to ensure extension usage while writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -e .
 
 # How to run it
 
-For a detailed walk-through of how to use the code, see ./notebooks/Demo.ipynb.
+**Note: For a detailed walk-through of how to use the code, see ./notebooks/Demo.ipynb.**
 
 ```python
 import nibabel as nb # for loading surfaces
@@ -81,7 +81,7 @@ plotting.view_surf([verts, faces],
 ```python
 # We can then save the map with:
 annot_name = '../data/freesurfer/fsaverage/label/lh.temporal.annot'
-F.write(annot_name, use_pretty_colors=True)
+F.write(annot_name)
 
 ```
 

--- a/fragmenter/Fragment.py
+++ b/fragmenter/Fragment.py
@@ -143,13 +143,19 @@ class Fragment(object):
             indicate whether to create a txt or csv file instead 
         """
 
-        # If labels are to be exported to csv
+        # If labels are to be exported to csv or txt
         if to_file:
-            np.savetxt(output_name, self.label_, fmt='%5.0f')
+            if output_name.endswith(('.txt','.csv')):
+                np.savetxt(output_name, self.label_, fmt='%5.0f')
+            else:    
+                print('Warning: neither csv or txt extensions provided...')
         # Otherwise write an annotation file with freesurfer    
         else:
-            [keys,ctab,names,remapped] = colormaps.get_ctab_and_names(
-                self.vertices, self.label_, use_pretty_colors=self.use_pretty_colors)
-            freesurfer.io.write_annot(output_name, remapped, ctab, names)
+            if output_name.endswith('.annot'):
+                [keys,ctab,names,remapped] = colormaps.get_ctab_and_names(
+                    self.vertices, self.label_, use_pretty_colors=self.use_pretty_colors)
+                freesurfer.io.write_annot(output_name, remapped, ctab, names)
+            else:
+                print('Warning: .annot file extension not provided...')    
 
 

--- a/notebooks/Demo.ipynb
+++ b/notebooks/Demo.ipynb
@@ -286,7 +286,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the sub-region colors then follow a gradient determined by the superior-inferior axis.  If we want to save the generated map, we can save the label to a FreeSurfer annotation file with:"
+    "Note that the sub-region colors then follow a gradient determined by the superior-inferior axis.  \n",
+    "\n",
+    "If we want to save the generated map, we can save the label to a FreeSurfer annotation file by using the writer function:"
    ]
   },
   {
@@ -295,15 +297,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Save a freesurfer map\n",
     "annot_name = '../data/freesurfer/temporal.annot'\n",
-    "temporal.write(annot_name, use_pretty_colors=True)"
+    "temporal.write(output_name=annot_name)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, if you want to save the label maps to export and use independently (say, in HCP's workbench, or in R), you can simply write them to a csv file. This can be useful if you are reducing the dimensionality of the cortex in order to run community detection algorithms in igraph (R version)."
+    "Axis color arrangement will be used if `use_pretty_colors` was originally set to `True` during the object generation.\n",
+    "\n",
+    "Alternatively, if you want to save the label maps to export and use independently (say, in HCP's workbench, or in R), you can easily write them to a csv or txt file using the `to_file` option. This can be useful if you are reducing the dimensionality of the cortex in order to run community detection algorithms in igraph (R version)."
    ]
   },
   {
@@ -313,13 +318,15 @@
    "outputs": [],
    "source": [
     "# Save for external use\n",
-    "np.savetxt(\"WBLabels.csv\", whole_brain.label_, '%5.0f')"
+    "temporal.write(output_name='temporal.txt', to_file=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Make sure to provide the file extension when giving the output name.\n",
+    "\n",
     "If you were fragmenting the HCP surface (e.g. 32k), you can produce a CIFTI dscalar.nii file to view in the workbench using the wb_command utilities. For example:"
    ]
   },


### PR DESCRIPTION
This PR complements the previous in 2 ways in response to #30:

1) It adds a test to make sure that the user provides a file extension to the writer's `output_name` (either 'csv', 'txt', or 'annot). This might be useful if someone runs many iterations automatically.

2) The Demo and README now reflect this new write usage.